### PR TITLE
fix: netlify redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
Отображается страница 404 на деплое при рефреше не главного рута. требуется проверка на деплоею Добавлен файл netlifu.toml с конфигурацией